### PR TITLE
Support collect logs of all the container state at the same time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 |----------------------|------------------|--------------------------------------------------------------------------------------------------------------|
 | `--container`        | `.*`             | Container name when multiple containers in pod (regular expression)                                          |
 | `--exclude-container`|                  | Container name to exclude when multiple containers in pod (regular expression)                               |
-| `--container-state`  | `running`        | Tail containers with status in running, waiting or terminated. Default to running.                           |
+| `--container-state`  | `running`        | Tail containers with status in running, waiting, terminated or all. Default to running.                      |
 | `--timestamps`       |                  | Print timestamps                                                                                             |
 | `--since`            |                  | Return logs newer than a relative duration like 52, 2m, or 3h. Displays all if omitted                       |
 | `--context`          |                  | Kubernetes context to use. Default to `kubectl config current-context`                                       |

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -76,7 +76,7 @@ func Run() {
 
 	cmd.Flags().StringVarP(&opts.container, "container", "c", opts.container, "Container name when multiple containers in pod")
 	cmd.Flags().StringVarP(&opts.excludeContainer, "exclude-container", "E", opts.excludeContainer, "Exclude a Container name")
-	cmd.Flags().StringSliceVar(&opts.containerState, "container-state", opts.containerState, "If present, tail containers with status in running, waiting or terminated. Default to running and waiting.")
+	cmd.Flags().StringSliceVar(&opts.containerState, "container-state", opts.containerState, "If present, tail containers with status in running, waiting, terminated or all. Default to running and waiting.")
 	cmd.Flags().BoolVarP(&opts.timestamps, "timestamps", "t", opts.timestamps, "Print timestamps")
 	cmd.Flags().DurationVarP(&opts.since, "since", "s", opts.since, "Return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to 48h.")
 	cmd.Flags().StringVar(&opts.context, "context", opts.context, "Kubernetes context to use. Default to current context configured in kubeconfig.")

--- a/stern/container_state.go
+++ b/stern/container_state.go
@@ -26,17 +26,18 @@ const (
 	RUNNING    = "running"
 	WAITING    = "waiting"
 	TERMINATED = "terminated"
+	ALL        = "all"
 )
 
 func NewContainerState(stateConfig []string) (ContainerState, error) {
 	var containerState []string
 	for _, p := range stateConfig {
-		if p == RUNNING || p == WAITING || p == TERMINATED {
+		if p == RUNNING || p == WAITING || p == TERMINATED || p == ALL {
 			containerState = append(containerState, p)
 		}
 	}
 	if len(containerState) == 0 {
-		return []string{}, errors.New("containerState should include 'running', 'waiting', or 'terminated'")
+		return []string{}, errors.New("containerState should include 'running', 'waiting', 'terminated', or 'all'")
 	}
 	return containerState, nil
 }


### PR DESCRIPTION
Support collection of logs for all container state. This is needed when we want to collect logs based on label for multiple container in different running or error state.